### PR TITLE
Remove usages of `l:js`

### DIFF
--- a/src/main/resources/io/jenkins/plugins/servicenow/BatchInstallBuilder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/servicenow/BatchInstallBuilder/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <l:js src="plugin/servicenow-cicd/js/snbuilders-support.js"/>
+    <script src="${rootURL}/plugin/servicenow-cicd/js/snbuilders-support.js" type="text/javascript" />
     <j:set var="builderId" value="${descriptor.generateBuilderId()}"/>
     <f:entry title="${%UseFile}" field="useFile">
         <f:checkbox onclick="BatchInstallBuilder.adjustVisibility('${builderId}', this.checked)"/>

--- a/src/main/resources/io/jenkins/plugins/servicenow/InstanceScanBuilder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/servicenow/InstanceScanBuilder/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
-    <l:js src="plugin/servicenow-cicd/js/snbuilders-support.js"/>
+    <script src="${rootURL}/plugin/servicenow-cicd/js/snbuilders-support.js" type="text/javascript" />
     <j:set var="builderId" value="${descriptor.generateBuilderId()}"/>
     <f:entry title="${%ScanType}" field="scanType">
         <f:select


### PR DESCRIPTION
Does not require https://github.com/jenkinsci/jenkins/pull/7827, but needed before https://github.com/jenkinsci/jenkins/pull/7827 can be merged and released. A timely merge and release of this PR would be of great assistance to the core developers with regard to unblocking https://github.com/jenkinsci/jenkins/pull/7827 and facilitating the removal of an undesirable dependency from Jenkins core. CC @chiarng