### PR TITLE
Uncaught `SyntaxError`: redeclaration of `const BatchInstallBuilder`

### DIFF
--- a/src/main/webapp/js/snbuilders-support.js
+++ b/src/main/webapp/js/snbuilders-support.js
@@ -1,7 +1,8 @@
 // Javascript code used by ServiceNow builders.
 // Created: April, 2021
 
-const BatchInstallBuilder = {
+if (typeof BatchInstallBuilder === "undefined") {
+  var BatchInstallBuilder = {
     adjustVisibility: (builderId, useFile) => {
         useFile = useFile || false;
         if (useFile) {
@@ -16,9 +17,11 @@ const BatchInstallBuilder = {
             Visibility.setVisibility(document.querySelector('#' + builderId + '-notes'), true);
         }
     }
+  }
 }
 
-const InstanceScanBuilder = {
+if (typeof InstanceScanBuilder === "undefined") {
+  var InstanceScanBuilder = {
     adjustVisibility: (builderId, scanType) => {
         switch(scanType) {
             case 'fullScan':
@@ -76,9 +79,11 @@ const InstanceScanBuilder = {
         Visibility.show(document.getElementById(builderId + '-suite'));
         Visibility.show(document.getElementById(builderId + '-requestBody'));
     }
+  }
 }
 
-const Visibility = {
+if (typeof Visibility === "undefined") {
+  var Visibility = {
     hide: (element) => {
         Visibility.setVisibility(element, false);
     },
@@ -97,5 +102,6 @@ const Visibility = {
         }
 
     }
+  }
 }
 


### PR DESCRIPTION
Amends #36 which caused "Uncaught `SyntaxError`: redeclaration of `const BatchInstallBuilder`" errors due to the script now being included twice. To fix this I made the script idempotent so that it could be loaded more than once without causing errors. I tested this interactively by creating a Freestyle project with both batch install and instance scan builders and verifying in the browser's JavaScript debugger that the handlers for both builders were being invoked correctly. I did have to clear my cache for the change to take effect, though.